### PR TITLE
Update Python version to 3.9.4 and dependencies

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -12,7 +12,7 @@ with the companion repo at https://github.com/miguelgrinberg/flasky
 Install dependencies
 
 ```bash
-conda create -n voice-collector python=3.7.16
+conda create -n voice-collector python=3.9.4
 conda activate voice-collector
 pip install -r requirements-dev.txt
 ```

--- a/server/requirements-common.txt
+++ b/server/requirements-common.txt
@@ -1,9 +1,12 @@
 # Common requirements used across local dev and production
-Flask==1.1.1
+Flask==2.2.3
 Flask-Cors==3.0.9
-gevent==1.4.0
 gunicorn==20.0.4
 transformers==4.26.1
 huggingsound==0.1.6
 jiwer==2.5.1
 metaphone==0.6
+werkzeug==2.0.3
+webrtcvad==2.0.10
+pydub==0.25.1
+gevent==22.10.2

--- a/server/requirements-common.txt
+++ b/server/requirements-common.txt
@@ -6,7 +6,7 @@ transformers==4.26.1
 huggingsound==0.1.6
 jiwer==2.5.1
 metaphone==0.6
-werkzeug==2.0.3
-webrtcvad==2.0.10
+werkzeug==2.2.2
+webrtcvad-wheels==2.0.11.post1
 pydub==0.25.1
 gevent==22.10.2


### PR DESCRIPTION
M1 MacBook requires Python > 3.8,  so we update the version and relative dependencies